### PR TITLE
SimpleNLG language switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ target/
 *$py.class
 cover
 tests/_trial_temp/
+
+# Backup files
+*~

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,5 @@
+2019-10-27 0.3.0+f1
+ * added additional argument `lang` to SimpleNLGServer constructor, to enable
+   setting the language to use in the SimpleNLG jar to be executed
+   (needs SimpleNLG fork)
+

--- a/nlglib/realisation/simplenlg/client.py
+++ b/nlglib/realisation/simplenlg/client.py
@@ -140,7 +140,13 @@ class SimpleNLGServer(threading.Thread):
 
     """
 
-    def __init__(self, jar_path, port):
+    def __init__(self, jar_path, port, lang=None):
+        '''
+         :param jar_path (str): SimpleNLG jarfile to launch
+         :param port (int): port where the server will listen for requests
+         :param lang (str): optional language argument to pass to SimpleNLG
+           to switch language for realisation (needs SimpleNLG fork)
+        '''
         super(SimpleNLGServer, self).__init__()
         log.debug('Creating simpleNLG server (%s)' % jar_path)
         log.debug('simpleNLG server port: ' + str(port))
@@ -149,6 +155,9 @@ class SimpleNLGServer(threading.Thread):
             raise ServerError(msg.format(jar_path))
         self.jar_path = jar_path
         self.port = str(port)
+        self.lang = str(lang).lower() if lang is not None else None
+        if self.lang is not None:
+            log.debug('simpleNLG server language: ' + self.lang)
         self.start_cv = threading.Condition()
         self.exit_cv = threading.Condition()
         self._ready = False
@@ -173,6 +182,8 @@ class SimpleNLGServer(threading.Thread):
 
         """
         args = ['java', '-Xmx512m', '-jar', self.jar_path, self.port]
+        if self.lang is not None:
+            args.append(self.lang)
         with self.error_log, self.output_log:
             with subprocess.Popen(
                 args,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def long_description():
 
 setup(
     name='nlglib',
-    version='0.2.1',
+    version='0.3.0+f1',
     description='Natural Language Generation library for Python',
     long_description=long_description(),
     author='Roman Kutlak',


### PR DESCRIPTION
 * added additional argument `lang` to SimpleNLGServer constructor, to enable setting the language to use in the SimpleNLG jar to be executed (note: needs SimpleNLG fork)